### PR TITLE
A few additions and fixes

### DIFF
--- a/Plugins/Freemoji/Freemoji.plugin.js
+++ b/Plugins/Freemoji/Freemoji.plugin.js
@@ -346,6 +346,7 @@ module.exports = (() => {
                                         i++;
                                     }
                                 }
+
                                 if (i == 0 && args[3].messageReference != undefined) {
                                     var firstMessage = message;
                                     firstMessage.content = text.join('\n').trim();

--- a/Plugins/Freemoji/Freemoji.plugin.js
+++ b/Plugins/Freemoji/Freemoji.plugin.js
@@ -320,34 +320,32 @@ module.exports = (() => {
                         Patcher.after(EmojiPickerListRow, 'default', (_, [{ emojiDescriptors }]) => {
                             emojiDescriptors.filter(e => e.wasDisabled).forEach(e => { e.isDisabled = true; delete e.wasDisabled; });
                         });
-                        
+
                         Patcher.after(SlateEditor.prototype, 'handleOnChange', (ThisEditor, args, ret) => {
                             this.LastEditor = [ThisEditor.props.editor, ThisEditor.props.channelId];
                         })
-                        
+
                         BdApi.Plugins.isEnabled("EmoteReplacer") || Patcher.instead(MessageUtilities, 'sendMessage', (thisObj, args, originalFn) => {
                             if (!this.settings.split || BdApi.Plugins.isEnabled("EmoteReplacer")) return originalFn.apply(thisObj, args);
                             const [channel, message] = args;
                             const split = message.content.split(EMOJI_SPLIT_LINK_REGEX).map(s => s.trim()).filter(s => s.length);
                             if (split.length <= 1) return originalFn.apply(thisObj, args);
-                            
+
                             const promises = [];
                             let finalSplitDelay = this.settings.splitDelay;
                             try {
                                 finalSplitDelay = BdApi.findModuleByProps("getChannel", "getDMFromUserId").getChannel(this.LastEditor[1]).rateLimitPerUser * 1000 + this.settings.splitDelay;
                             } catch {}
-                            
+
                             for (let i = 0; i < split.length; i++) {
-                                const text = [split[i]]; 
-                                
-                                if (this.settings.splitLimit != 0 && i > this.settings.splitLimit-1) {
+                                const text = [split[i]];
+                                if (this.settings.splitLimit != 0 && i > this.settings.splitLimit - 1) {
                                     i++;
                                     while (i < split.length) {
                                         text.push(split[i]);
                                         i++;
                                     }
                                 }
-                                
                                 if (i == 0 && args[3].messageReference != undefined) {
                                     var firstMessage = message;
                                     firstMessage.content = text.join('\n').trim();
@@ -355,9 +353,9 @@ module.exports = (() => {
                                     originalFn.apply(thisObj, args);
                                     continue;
                                 }
-                                
+
                                 if (text.join('\n').trim() != "") {
-                                    if (this.settings.splitLimitMode && i > this.settings.splitLimit-1) {
+                                    if (this.settings.splitLimitMode && i > this.settings.splitLimit - 1) {
                                         if (this.LastEditor != undefined) {
                                             setTimeout(this.LastEditor[0].insertText, this.settings.splitLimit * finalSplitDelay, text.join('\n').trim());
                                         } else {

--- a/Plugins/Freemoji/Freemoji.plugin.js
+++ b/Plugins/Freemoji/Freemoji.plugin.js
@@ -127,6 +127,13 @@ module.exports = (() => {
                         value: 'allow'
                     }
                 ]
+            },
+            {
+                type: 'switch',
+                id: 'replacePNG',
+                name: 'Use PNG instead of WEBP',
+                note: 'If the emoji url points to a webp image, replace it with a png',
+                value: false
             }
         ]
     };
@@ -330,9 +337,13 @@ module.exports = (() => {
                     }
 
                     getEmojiUrl(emoji) {
-                        return emoji.url.includes("size=") ?
-                            emoji.url.replace(SIZE_REGEX, `$1${this.settings.emojiSize}`) :
-                            `${emoji.url}&size=${this.settings.emojiSize}`;
+                        var finalEmojiURL = emoji.url;
+                        if (this.settings.replacePNG) {
+                            finalEmojiURL = finalEmojiURL.replace(".webp?", ".png?");
+                        }
+                        return finalEmojiURL.includes("size=") ?
+                            finalEmojiURL.replace(SIZE_REGEX, `$1${this.settings.emojiSize}`) :
+                            `${finalEmojiURL}&size=${this.settings.emojiSize}`;
                     }
 
                     hasEmbedPerms(channelParam) {

--- a/Plugins/Freemoji/Freemoji.plugin.js
+++ b/Plugins/Freemoji/Freemoji.plugin.js
@@ -63,7 +63,8 @@ module.exports = (() => {
                 note: 'The delay between each split message in ms.',
                 value: 100,
                 markers: [50, 100, 150, 200, 250, 500, 750, 1000],
-                stickToMarkers: true
+                stickToMarkers: true,
+                defaultValue: 100
             },
             {
                 type: 'switch',
@@ -79,7 +80,8 @@ module.exports = (() => {
                 note: 'Prevent the user from sending more than this many split messages at once. This setting and the one below is disabled if the value is set to zero.',
                 value: 4,
                 markers: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-                stickToMarkers: true
+                stickToMarkers: true,
+                defaultValue: 4
             },
             {
                 type: 'dropdown',
@@ -105,6 +107,7 @@ module.exports = (() => {
                 note: 'The size of the emoji in pixels. 48 is recommended because it is the size of regular Discord emoji.',
                 value: 48,
                 markers: [32, 40, 48, 60, 64, 80, 96],
+                defaultValue: 48,
                 stickToMarkers: true
             },
             {

--- a/Plugins/Freemoji/Freemoji.plugin.js
+++ b/Plugins/Freemoji/Freemoji.plugin.js
@@ -290,6 +290,14 @@ module.exports = (() => {
                                         originalFn.call(thisObj, channel, { content: text, validNonShortcutEmojis: [] }).then(resolve).catch(reject);
                                     }, i * 100);
                                 }));
+                                if (i == 0 && args[3].messageReference != undefined) {
+                                    var firstMessage = message;
+                                    firstMessage.content = text;
+                                    args.message = firstMessage;
+                                    originalFn.apply(thisObj, args);
+                                    continue;
+                                }
+                                
                             }
                             return Promise.all(promises).then(ret => ret[ret.length - 1]);
                         });


### PR DESCRIPTION
Fixed issues #59 and #46.
Added an option to:
 - Change the delay between each split message
 - Add the channel's slowmode length to the delay above
 - Limit the maximum number of split messages sent at once
 - Determine what's done with any of the extra messages that won't be sent due to the split message limit

Also added 'defaultValue' attribute to each slider option, set to the actual default values.