### PR TITLE
Final grammar check.

### DIFF
--- a/Plugins/Freemoji/DISCONTINUATION.md
+++ b/Plugins/Freemoji/DISCONTINUATION.md
@@ -1,51 +1,51 @@
 # Discontinuation
 
-As of September 8th, 2022 the Freemoji plugin is discontinued. The plugin will not receive any further updates - if it breaks, it stays broken.
+As of September 8th, 2022, the Freemoji plugin is discontinued. The plugin will not receive any further updates - if it breaks, it stays broken.
 
-The main reason for that is my disappointment and disgust upon seeing some of the reactions and hate coming from the community following the recent guideline updates and the discontinuation of the ShowHiddenChannels plugin. The reason is not the updated guidelines, but the obnoxious community.
+The main reason is my disappointment and disgust upon seeing the reactions and hate coming from the community following the recent guideline updates and the discontinuation of the ShowHiddenChannels plugin. The reason is not the updated guidelines but the obnoxious community.
 
 ## The Guidelines
 
-To clarify, and stop people from spreading more misinformation: The Freemoji plugin was **not** affected by these updated guidelines, and would still be allowed to be an official plugin. But I do no longer wish to cater to people who cry "censorship" because somebody broke their toy that allowed them to see things they weren't supposed to.
+To clarify and stop people from spreading more misinformation: The Freemoji plugin was **not** affected by these updated guidelines and would still be allowed to be an official plugin. But I no longer wish to cater to people who cry "censorship" because somebody broke their toy that allowed them to see things they weren't supposed to.
 
-Developers were notified about the updated guidelines as early as [July 16th](https://github.com/BetterDiscord/docs/blob/3add40bdda0afbadc6c0af09d10413bbdee54f5f/src/plugins/introduction/guidelines.md). They have been in the works much earlier than that, and there were discussions about banning ShowHiddenChannels since pretty much as long as that plugin existed.
+The BetterDiscord team notified developers about the updated guidelines sometime around [July 16th](https://github.com/BetterDiscord/docs/blob/3add40bdda0afbadc6c0af09d10413bbdee54f5f/src/plugins/introduction/guidelines.md). They have been in the works much earlier than that. There were discussions about banning ShowHiddenChannels for as long as that plugin existed.
 
 To the people calling BetterDiscord hypocrites for not banning free emoji plugins, I've heard you loud and clear and removed the only working official free emoji plugin from the store. \*winky face\*
 
-For some reason, discussions about message loggers came up surrounding these changes. Message loggers were already banned before the update. There was never an official message logging plugin, nothing changed there.
+For some reason, discussions about message loggers came up surrounding these changes. However, message loggers were already banned before the update. There was never an official message logging plugin; nothing changed there.
 
 ## Annoying Maintenance
 
 Before I get to the gritty part, some minor reasons for me not working on this plugin anymore that added up over time:
 
 * people asking for help, completely ignoring whatever guide they came from
-  * it's not my job to teach people how to use BD
-  * it's not my job to teach people how to use their Windows PC
+  * I am not the one that handles teaching people how to use BD
+  * I am not the one that handles teaching people how to use their Windows PC
 * having to maintain parts that I literally couldn't care less about
   * message splitting
-  * typing out the names of emoji - I always use the emoji picker
-* it's no fun to develop and takes away motivation for other plugins
+  * typing out the names of emojis - I always use the emoji picker
+* it's no fun to develop and takes away the motivation for other plugins
 * I originally made the plugin for a friend who would have otherwise resorted to unofficial plugins - said friend has nitro now
-  * the first iteration was a fork of NitroPerks
+  * The first iteration was a fork of NitroPerks
   * I later rewrote it to be a fork of DiscordFreeEmojis with some features inspired by NitroPerks and some new ones on top
 
-I'd like to thank GitHub user FrostBird347 for his recent contributions to the plugin though. They were and still are very appreciated.
+However, I want to thank GitHub user FrostBird347 for his recent contributions to the plugin. They were and still are very appreciated.
 
 ## ShowHiddenChannels
 
-I'm in complete support of the BetterDiscord team and the updated guidelines that ban ShowHiddenChannels. I don't condemn the way DevilBro handled the update, aside from the part where the update was applied without user interaction, the mechanism that did that has since been removed from BDFDB and will not happen again.
+I support entirely the BetterDiscord team and the updated guidelines that ban ShowHiddenChannels. I don't condemn DevilBro's handling of the update. Aside from DevilBro applying the update without user interaction, the mechanism he used has since been removed from BDFDB and will not happen again.
 
-Updating the BDFDB data file to remove the then unused entries that were previously used by ShowHiddenChannels is also completely understandable, and I would probably have done the same. Calling the way he handled the update malicious is nonsense. It didn't do any harm to the user, users aren't entitled to have the plugin continue functioning, malice would be stealing the user's account, or bricking their system.
+Updating the BDFDB data file to remove the unused entries that ShowHiddenChannels previously used is also completely understandable. I would probably have done the same. Calling the way he handled the update malicious is nonsense. It didn't harm the user, and users are not entitled to have the plugin continue functioning. Malice would be stealing the user's account, or bricking their system.
 
 ## The Tinfoil Hats
 
-The recent events revealed a lot of creeps and tinfoil hats that absolutely validate that banning ShowHiddenChannels was a good thing. People who threatened developers, harassed BD staff, were generally insulting, all that while thinking of themselves as the reasonable heroes that were unfairly censored by BetterDiscord. These guys aren't heroes, they are creeps that should really get a life and stop being assholes.
+The recent events revealed a lot of creeps and tinfoil hats that validate that banning ShowHiddenChannels was a good thing. People who threatened developers, and harassed BD staff, were generally insulting, all that while thinking of themselves as the reasonable heroes unfairly censored by BetterDiscord. These guys aren't heroes; they are creeps that should get a life and stop being assholes.
 
-Some rumor circulated about somebody named "keffels" being behind all this, and this all being a big conspiracy with them pulling the strings.... Only that no one in the community ever heard of them before that rumor. ~~Apparently, they are in part responsible for taking down a forum known for doxxing, harassing, and even driving people into suicide, so I should probably check him out at some point.~~ (Edit: Scratch that last part, looks like they aren't such a great person after all.)
+Some rumor circulated about somebody named "keffels" being behind all this, and this all being a big conspiracy with them pulling the strings... Only that no one in the community had heard of them before that rumor. ~~Apparently, they are partly responsible for taking down a forum known for doxxing, harassing, and even driving people into suicide. I should probably check him out at some point.~~ (Edit: Scratch that last part, it looks like they aren't such a great person after all.)
 
 ## Reddit
 
-Also, just as a bit of a Reddit sidenote. **There is no official BetterDiscord subreddit.** The r/BetterDiscord subreddit is run by a single person who is not connected to the BetterDiscord project. The person running it doesn't like people saying that and linking to the official Discord server. This person doesn't hesitate to ban people who are actually connected to BD when they say things he doesn't like, such as linking to the official channels.
+Also, just a bit of a Reddit sidenote: **There is no official BetterDiscord subreddit.** A single person runs the r/BetterDiscord subreddit with no connection to the BetterDiscord project. The person running it doesn't like people saying that and linking to the official Discord server. This person doesn't hesitate to ban people connected to BD when they say things he doesn't like, such as linking to the official channels.
 
 The only official BetterDiscord channels are:
 
@@ -54,6 +54,6 @@ The only official BetterDiscord channels are:
 * [the Twitter Account](https://twitter.com/_BetterDiscord_)
 * and [the GitHub Organization](https://github.com/BetterDiscord)
 
-## P.S.
+## PS.
 
-I completely forgot EmoteReplacer exists. It's a really well-made official plugin and is also a type of free emoji plugin, even if it works a bit different from Freemoji. But I like the sass in the paragraph about BetterDiscord's supposed hypocrisy, so I'll leave it unchanged.
+I completely forgot that EmoteReplacer exists. It's a well-made official plugin and a free emoji plugin, even if it works a bit differently from Freemoji. But I like the sass in the paragraph about BetterDiscord's supposed hypocrisy, so I'll leave it unchanged.

--- a/Plugins/Freemoji/DISCONTINUATION.md
+++ b/Plugins/Freemoji/DISCONTINUATION.md
@@ -35,7 +35,7 @@ However, I want to thank GitHub user FrostBird347 for his recent contributions t
 
 I support entirely the BetterDiscord team and the updated guidelines that ban ShowHiddenChannels. I don't condemn DevilBro's handling of the update. Aside from DevilBro applying the update without user interaction, the mechanism he used has since been removed from BDFDB and will not happen again.
 
-Updating the BDFDB data file to remove the unused entries that ShowHiddenChannels previously used is also completely understandable. I would probably have done the same. Calling the way he handled the update malicious is nonsense. It didn't harm the user, and users are not entitled to have the plugin continue functioning. Malice would be stealing the user's account, or bricking their system.
+Updating the BDFDB data file to remove the unused entries that ShowHiddenChannels previously used is also completely understandable. I would probably have done the same. Calling the way he handled the update malicious is nonsense. It didn't harm the user, and users are not entitled to have the plugin continue functioning. Malice would be stealing the user's account or bricking their system.
 
 ## The Tinfoil Hats
 
@@ -56,4 +56,4 @@ The only official BetterDiscord channels are:
 
 ## PS.
 
-I completely forgot that EmoteReplacer exists. It's a well-made official plugin and a free emoji plugin, even if it works a bit differently from Freemoji. But I like the sass in the paragraph about BetterDiscord's supposed hypocrisy, so I'll leave it unchanged.
+I completely forgot that EmoteReplacer exists. It's a well-made official plugin and a free emoji plugin, even if it works differently from Freemoji. But I like the sass in the paragraph about BetterDiscord's supposed hypocrisy, so I'll leave it unchanged.


### PR DESCRIPTION
I bought a subscription to Grammarly and manually checked every suggestion, doing my best to fix any errors that required manual attention.

Things that still require attention:

> But I no longer wish to cater to people who cry "censorship" because somebody broke their toy that allowed them to see things they weren't supposed to.

Grammarly claims that "their toy" should be replaced with "the toy." While the word "the" suggests that there is only one toy - which is true if "toy" is referencing ShowHiddenChannels - I wholeheartedly believe that one should reference every user's instance of "the toy" as their own. Therefore, their toy.

> However, message loggers were already banned before the update.

Grammarly claims this sentence is too passive and should be rewritten in a more active voice. Unfortunately, I do not know how to speak in a "more active voice."

> Some rumor circulated about somebody named "keffels" being behind all this

Grammarly cries at the word "keffels," stating that it is not an accurate word. Capitalizing the name (as you should with names) fixes this. However, I left it as-is because I believe you should not capitalize usernames willy-nilly.

> A single person runs the r/BetterDiscord subreddit with no connection to the BetterDiscord project.

Despite my best attempts at fixing this grammar error, Grammarly claims that "with no connection" should be replaced with "without connecting." However, when a person is speaking in terms of _their connections to another user or team_, the term used should be "their connection," not "their connecting." The mistake appears to be a mistake on Grammarly's part.

With that in mind, these are all possible fixes one could ever desire. But, of course, you are free to close this request and nit-pick which edits to wish to add manually.
